### PR TITLE
Fixed thread crash

### DIFF
--- a/core/include/prometheus/save_to_file.h
+++ b/core/include/prometheus/save_to_file.h
@@ -30,7 +30,13 @@ namespace prometheus {
     }
     
   public:
-    SaveToFile() {}
+    SaveToFile() = default;
+
+    ~SaveToFile() {
+      if (worker_thread.joinable())
+        worker_thread.detach();
+    }
+
     SaveToFile(Registry& registry_, const std::chrono::seconds& period_, const std::string& filename_) {
       set_registry(registry_);
       set_delay(period_);

--- a/examples/save_to_file_example.cpp
+++ b/examples/save_to_file_example.cpp
@@ -23,7 +23,7 @@ int main() {
   // @note it's the users responsibility to keep the object alive
   Registry registry;
 
-  SaveToFile saver = SaveToFile( registry, std::chrono::seconds(5), std::string("./metrics.prom") );
+  SaveToFile saver( registry, std::chrono::seconds(5), std::string("./metrics.prom") );
 
   // add a new counter family to the registry (families combine values with the
   // same name, but distinct label dimensions)

--- a/simpleapi/src/simpleapi.cpp
+++ b/simpleapi/src/simpleapi.cpp
@@ -6,7 +6,7 @@ namespace prometheus {
   namespace simpleapi {
 
     Registry registry;
-    SaveToFile saver = SaveToFile(registry, std::chrono::seconds(5), std::string("./metrics.prom"));
+    SaveToFile saver(registry, std::chrono::seconds(5), std::string("./metrics.prom"));
 
   }
 }


### PR DESCRIPTION
In  the destructor of thread  there is a check on the fact that the active thread is
"join" or "detach". And if earlier not to make "join/detach" an exception arises.