### PR TITLE
Bug fixes on the GCC compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .vs
 bin/
 out/
+build/
+
+*.user

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -10,3 +10,8 @@ target_include_directories(${PROJECT_NAME}     INTERFACE ${CMAKE_CURRENT_SOURCE_
 add_custom_target         (${PROJECT_NAME}-ide SOURCES   ${PROMETHEUS_CPP_LITE_HEADERS})
 
 set                       (${PROJECT_NAME}_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include PARENT_SCOPE)
+
+if(NOT WIN32)
+  find_package(Threads)
+  target_link_libraries(${PROJECT_NAME} INTERFACE ${CMAKE_THREAD_LIBS_INIT})
+endif()

--- a/core/include/prometheus/builder.h
+++ b/core/include/prometheus/builder.h
@@ -13,7 +13,7 @@ namespace prometheus {
     std::string help_;
 
   public:
-    Builder& Labels(const std::map<std::string, std::string>& labels) {
+    Builder& Labels(const std::map<const std::string, const std::string>& labels) {
       labels_ = labels;
       return *this;
     }

--- a/core/include/prometheus/family.h
+++ b/core/include/prometheus/family.h
@@ -239,11 +239,11 @@ namespace prometheus {
 
           ClientMetric collected = metric_pair.second->Collect();
           for (const Label& constant_label : constant_labels)
-            collected.label.push_back(std::move(ClientMetric::Label(constant_label.first, constant_label.second)));
+            collected.label.emplace_back(ClientMetric::Label(constant_label.first, constant_label.second));
 
           const Labels& metric_labels = labels.at(metric_pair.first);
           for (const Label& metric_label : metric_labels)
-            collected.label.push_back(std::move(ClientMetric::Label(metric_label.first, metric_label.second)));
+            collected.label.emplace_back(ClientMetric::Label(metric_label.first, metric_label.second));
 
           family.metric.push_back(std::move(collected));
 
@@ -346,7 +346,7 @@ namespace prometheus {
       /// Register(Registry&).
       template <typename Registry>
       static CustomFamily& Build(Registry& registry, const std::string& name, const std::string& help, const Family::Labels& labels = Family::Labels()) {
-        return registry.Add<CustomFamily>(name, help, labels);
+        return registry.template Add<CustomFamily>(name, help, labels);
       }
 
   };

--- a/examples/modern_example.cpp
+++ b/examples/modern_example.cpp
@@ -53,7 +53,7 @@ int main() {
     if (random_value & 8) udp_tx_counter += 0.7;
 
     const std::array<std::string, 4> methods = { "GET", "PUT", "POST", "HEAD" };
-    const std::string& method = methods.at(random_value % methods.size());
+    const std::string& method = methods.at(static_cast<std::size_t>(random_value) % methods.size());
 
     // dynamically calling Family<T>.Add() works but is slow and should be avoided
     http_requests_counter.Add({ {"method", method} }) += 10;
@@ -62,7 +62,4 @@ int main() {
     text_serializer.Serialize(std::cout, registry.Collect());
 
   }
-
-  return 0;
-
 }

--- a/examples/original_example.cpp
+++ b/examples/original_example.cpp
@@ -56,7 +56,7 @@ int main() {
     if (random_value & 8) udp_tx_counter.Increment(10);
 
     const std::array<std::string, 4> methods = { "GET", "PUT", "POST", "HEAD" };
-    auto method = methods.at(random_value % methods.size());
+    auto method = methods.at(static_cast<std::size_t>(random_value) % methods.size());
     // dynamically calling Family<T>.Add() works but is slow and should be avoided
     http_requests_counter.Add({ {"method", method} }).Increment();
 
@@ -64,6 +64,4 @@ int main() {
     text_serializer.Serialize(std::cout, registry->Collect());
 
   }
-
-  return 0;
 }

--- a/examples/save_to_file_example.cpp
+++ b/examples/save_to_file_example.cpp
@@ -40,7 +40,4 @@ int main() {
     const int random_value = std::rand();
     metric += random_value % 10;
   }
-
-  return 0;
-
 }

--- a/examples/use_benchmark_in_class_example.cpp
+++ b/examples/use_benchmark_in_class_example.cpp
@@ -14,7 +14,7 @@
 using namespace prometheus;
 
 // create global registry for use it from our classes
-Registry globalRegistry;
+static Registry globalRegistry;
 
 class MyClass {
 
@@ -55,7 +55,5 @@ int main() {
     text_serializer.Serialize(std::cout, globalRegistry.Collect());
 
   }
-
-  return 0;
 }
 

--- a/examples/use_counters_in_class_example.cpp
+++ b/examples/use_counters_in_class_example.cpp
@@ -21,7 +21,7 @@ using IntegerCounterFamily  = CustomFamily<IntegerCounter>;
 using FloatingCounterFamily = CustomFamily<FloatingCounter>;
 
 // create global registry for use it from our classes
-Registry globalRegistry;
+static Registry globalRegistry;
 
 class MyClass {
 
@@ -75,7 +75,5 @@ int main() {
     text_serializer.Serialize(std::cout, globalRegistry.Collect());
 
   }
-
-  return 0;
 }
 

--- a/examples/use_gauge_in_class_example.cpp
+++ b/examples/use_gauge_in_class_example.cpp
@@ -21,7 +21,7 @@ using IntegerGaugeFamily  = CustomFamily<IntegerGauge>;
 using FloatingGaugeFamily = CustomFamily<FloatingGauge>;
 
 // create global registry for use it from our classes
-Registry globalRegistry;
+static Registry globalRegistry;
 
 class MyClass {
 
@@ -75,7 +75,5 @@ int main() {
     text_serializer.Serialize(std::cout, globalRegistry.Collect());
 
   }
-
-  return 0;
 }
 


### PR DESCRIPTION
 - Adding new conditions to .gitignore

 - Fixed mismatch type

 - Added thread library

 - When building the project, a library for working with threads was
 required.

 - Fixed redundancy and unnecessary copying

   std :: move is redundant, since there will be copy elisions on
   push_back. It is better to use emplace_back because the object
   will be created in the location provided by the container.

 - Compiler warning about loss of 'typename'

 - Fixed warning about implicit conversion

 - Fixed warning about 'return' will never be executed

 - Fixed warning about no previous extern declaration for non-static variable