### PR TITLE
Histogram, inherit from public Metric

### DIFF
--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -27,7 +27,7 @@ namespace prometheus {
   /// The class is thread-safe. No concurrent call to any API of this type causes
   /// a data race.
   template <typename Value_ = uint64_t>
-  class Histogram : Metric {
+  class Histogram : public Metric {
 
       using BucketBoundaries = std::vector<Value_>;
 


### PR DESCRIPTION
Potential fix for #15?

Updates `Histogram` to be a public subtype of `Metric`, like the other subtypes

* https://github.com/biaks/prometheus-cpp-lite/blob/8f252c36e55d8a82cae16df9eeed9ed64199643c/core/include/prometheus/gauge.h#L27
* https://github.com/biaks/prometheus-cpp-lite/blob/8f252c36e55d8a82cae16df9eeed9ed64199643c/core/include/prometheus/counter.h#L29



I made this change and now CLion isn't now throwing warnings at me, but I haven't tested it yet.