### PR TITLE
Fixed some bugs in Histogram class. Made it to work with templates correctly.

### DIFF
--- a/core/include/prometheus/client_metric.h
+++ b/core/include/prometheus/client_metric.h
@@ -3,11 +3,11 @@
 #include <cstdint>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 namespace prometheus {
 
-  // структура, в которую копируются значения метрик перед их сериализацией
   struct ClientMetric {
 
     // Label
@@ -17,7 +17,7 @@ namespace prometheus {
       std::string name;
       std::string value;
 
-      Label(const std::string name_, const std::string value_) : name(name_), value(value_) {}
+      Label(std::string name_, std::string value_) : name(std::move(name_)), value(std::move(value_)) {}
 
       bool operator<(const Label& rhs) const {
         return std::tie(name, value) < std::tie(rhs.name, rhs.value);

--- a/core/include/prometheus/counter.h
+++ b/core/include/prometheus/counter.h
@@ -28,7 +28,7 @@ namespace prometheus {
   template <typename Value_ = uint64_t>
   class Counter : public Metric {
 
-    std::atomic<Value_> value{ 0 };
+    std::atomic<Value_> value{};
 
   public:
 

--- a/core/include/prometheus/family.h
+++ b/core/include/prometheus/family.h
@@ -87,10 +87,10 @@ namespace prometheus {
       static bool isLocaleIndependentDigit        (char c) { return '0' <= c && c <= '9'; }
       static bool isLocaleIndependentAlphaNumeric (char c) { return isLocaleIndependentDigit(c) || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z'); }
 
-      bool nameStartsValid (const std::string& name) {
-        if (name.empty())                           return false; // must not be empty
-        if (isLocaleIndependentDigit(name.front())) return false; // must not start with a digit
-        if (name.compare(0, 2, "__") == 0)          return false; // must not start with "__"
+      bool nameStartsValid (const std::string& cur_name) {
+        if (cur_name.empty())                           return false; // must not be empty
+        if (isLocaleIndependentDigit(cur_name.front())) return false; // must not start with a digit
+        if (cur_name.compare(0, 2, "__") == 0)          return false; // must not start with "__"
         return true;
       }
 
@@ -102,12 +102,12 @@ namespace prometheus {
       ///
       /// \param name metric name
       /// \return true is valid, false otherwise
-      bool CheckMetricName (const std::string& name) {
+      bool CheckMetricName (const std::string& cur_name) {
 
-        if (!nameStartsValid(name))
+        if (!nameStartsValid(cur_name))
           return false;
 
-        for (const char& c : name)
+        for (const char& c : cur_name)
           if ( !isLocaleIndependentAlphaNumeric(c) && c != '_' && c != ':' )
             return false;
 
@@ -123,12 +123,12 @@ namespace prometheus {
       ///
       /// \param name label name
       /// \return true is valid, false otherwise
-      bool CheckLabelName (const std::string& name) {
+      bool CheckLabelName (const std::string& cur_name) {
 
-        if (!nameStartsValid(name))
+        if (!nameStartsValid(cur_name))
           return false;
 
-        for (const char& c : name)
+        for (const char& c : cur_name)
           if (!isLocaleIndependentAlphaNumeric(c) && c != '_')
             return false;
 
@@ -198,8 +198,8 @@ namespace prometheus {
       /// \brief Returns true if the dimensional data with the given labels exist
       ///
       /// \param labels A set of key-value pairs (= labels) of the dimensional data.
-      bool Has (const Labels& labels) const {
-        const Hash hash = hash_labels (labels);
+      bool Has (const Labels& cur_labels) const {
+        const Hash hash = hash_labels (cur_labels);
         std::lock_guard<std::mutex> lock{ mutex };
         return metrics.find(hash) != metrics.end();
       }
@@ -262,8 +262,9 @@ namespace prometheus {
 
       static const Metric::Type static_type = CustomMetric::static_type;
 
-      CustomFamily(const std::string& name, const std::string& help, const Family::Labels& constant_labels)
-        : Family(static_type, name, help, constant_labels) {}
+      CustomFamily(const std::string& name_, const std::string& help_,
+                   const Family::Labels& constant_labels_)
+        : Family(static_type, name_, help_, constant_labels_) {}
 
       /// \brief Add a new dimensional data.
       ///

--- a/core/include/prometheus/histogram.h
+++ b/core/include/prometheus/histogram.h
@@ -103,9 +103,9 @@ namespace prometheus {
           cumulative_count += static_cast<std::size_t>(bucket_counts_[i].Get());
           auto bucket = ClientMetric::Bucket{};
           bucket.cumulative_count = cumulative_count;
-          bucket.upper_bound = static_cast<double>((i == bucket_boundaries_.size()
-                                                    ? std::numeric_limits<Value>::infinity()
-                                                    : bucket_boundaries_[i]));
+          bucket.upper_bound = i == bucket_boundaries_.size()
+                               ? std::numeric_limits<double>::infinity()
+                               : static_cast<double>(bucket_boundaries_[i]);
           metric.histogram.bucket.push_back(std::move(bucket));
         }
         metric.histogram.sample_count = cumulative_count;


### PR DESCRIPTION
These are some useful changes that were made to the repository. The histogram class was not being compiled with any template parameter not equal to  'double'. Also, some general changes will make the library a bit faster. Also, some Clang-Tidy warnings have been removed.