### PR TITLE
Add CMake installation rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 project(prometheus-cpp-lite)
+
+include(GNUInstallDirs)
+
 cmake_minimum_required(VERSION 3.2)
 
 option(PROMETHEUS_BUILD_EXAMPLES "Build with examples" OFF)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -18,3 +18,6 @@ if(NOT WIN32)
   find_package(Threads)
   target_link_libraries(${PROJECT_NAME} INTERFACE ${CMAKE_THREAD_LIBS_INIT})
 endif()
+
+install                   (TARGETS ${PROJECT_NAME})
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
This is necessary to install the header only library in a distro package.